### PR TITLE
[dps] fix Dot/Hot calculation from status of the StatusList

### DIFF
--- a/src/Athavar.FFXIV.Plugin.Dps/EncounterManager.Input.cs
+++ b/src/Athavar.FFXIV.Plugin.Dps/EncounterManager.Input.cs
@@ -4,6 +4,7 @@
 // </copyright>
 namespace Athavar.FFXIV.Plugin.Dps;
 
+using Athavar.FFXIV.Plugin.Common.Definitions;
 using Athavar.FFXIV.Plugin.Dps.Data;
 using Athavar.FFXIV.Plugin.Dps.Data.Encounter;
 using Dalamud.Game.ClientState.Objects.Types;
@@ -149,7 +150,7 @@ internal sealed partial class EncounterManager
                     var targetObject = this.objectTable?.SearchById(dotEvent.TargetId);
                     if (targetObject is BattleChara battleChara)
                     {
-                        var affectedStatusList = battleChara.StatusList.Select(s => (Status: this.definitions.GetStatusEffectById(s.StatusId), Source: encounter.GetCombatant(s.SourceId))).Where(s => s.Status?.TimeProc is not null).ToList();
+                        var affectedStatusList = battleChara.StatusList.Select(s => (Status: this.definitions.GetStatusEffectById(s.StatusId), Source: encounter.GetCombatant(s.SourceId))).Where(s => s.Status?.TimeProc?.Type is TimeProc.TickType.DoT).ToList();
                         if (affectedStatusList.Any())
                         {
                             // only calculate amount based on potency. Buffs are not calculated in.
@@ -195,7 +196,7 @@ internal sealed partial class EncounterManager
                     var targetObject = this.objectTable?.SearchById(hotEvent.TargetId);
                     if (targetObject is BattleChara battleChara)
                     {
-                        var affectedStatusList = battleChara.StatusList.Select(s => (Status: this.definitions.GetStatusEffectById(s.StatusId), Source: encounter.GetCombatant(s.SourceId))).Where(s => s.Status?.TimeProc is not null).ToList();
+                        var affectedStatusList = battleChara.StatusList.Select(s => (Status: this.definitions.GetStatusEffectById(s.StatusId), Source: encounter.GetCombatant(s.SourceId))).Where(s => s.Status?.TimeProc?.Type is TimeProc.TickType.HoT).ToList();
                         if (affectedStatusList.Any())
                         {
                             // only calculate amount based on potency. Buffs are not calculated in.

--- a/src/Athavar.FFXIV.Plugin.Dps/EncounterManager.Input.cs
+++ b/src/Athavar.FFXIV.Plugin.Dps/EncounterManager.Input.cs
@@ -158,7 +158,8 @@ internal sealed partial class EncounterManager
                             var totalAmount = dotEvent.Amount;
                             foreach (var (status, combatant) in affectedStatusList)
                             {
-                                var calc = (uint)(totalAmount * ((double)status!.TimeProc!.Potency / combinedPotency));
+                                var multi = (double)status!.TimeProc!.Potency / combinedPotency;
+                                var calc = (uint)(totalAmount * multi);
                                 if (calc == 0)
                                 {
                                     continue;
@@ -200,20 +201,24 @@ internal sealed partial class EncounterManager
                             // only calculate amount based on potency. Buffs are not calculated in.
                             handled = true;
                             var combinedPotency = affectedStatusList.Sum(s => s.Status!.TimeProc!.Potency);
-                            var totalAmount = hotEvent.Amount;
+                            var totalHeal = hotEvent.Amount;
+                            var totalOverHeal = hotEvent.Overheal;
                             foreach (var (status, combatant) in affectedStatusList)
                             {
-                                var calc = (uint)(totalAmount * ((double)status!.TimeProc!.Potency / combinedPotency));
-                                if (calc == 0)
+                                var multi = (double)status!.TimeProc!.Potency / combinedPotency;
+                                var calcHeal = (uint)(totalHeal * multi);
+                                var calcOverHeal = (uint)(totalOverHeal * multi);
+                                if (calcHeal == 0)
                                 {
                                     continue;
                                 }
 
-                                hotEvent.Amount = calc;
+                                hotEvent.Amount = calcHeal;
+                                hotEvent.Overheal = calcOverHeal;
                                 hotEvent.StatusId = status.Id;
                                 combatant?.AddActionDone(@event.Timestamp, hotEvent);
                                 target?.AddActionTaken(@event.Timestamp, hotEvent);
-                                this.Log.Add($"{@event.Timestamp:O}|HoT|{combatant?.Name}|{target?.Name}|{this.utils.StatusString(hotEvent.StatusId)}|{hotEvent.Amount} of {totalAmount}");
+                                this.Log.Add($"{@event.Timestamp:O}|HoT|{combatant?.Name}|{target?.Name}|{this.utils.StatusString(hotEvent.StatusId)}|{hotEvent.Amount} of {totalHeal}");
                             }
                         }
                     }


### PR DESCRIPTION
- fix status overheal calculation
- only use status from the statusList for the correct CombatEvent Type