### PR TITLE
fix final appraisal is skipping buff tick

### DIFF
--- a/src/Athavar.FFXIV.Plugin.Config/Configurations/Configuration.cs
+++ b/src/Athavar.FFXIV.Plugin.Config/Configurations/Configuration.cs
@@ -81,7 +81,7 @@ public sealed class Configuration : IPluginConfiguration
         if (c.Version == 1)
         {
             c.Setup(pi);
-            pi.ConfigFile.MoveTo($"{pi.ConfigFile.Name}.old");
+            pi.ConfigFile.MoveTo(Path.Combine(pi.ConfigFile.Directory?.FullName ?? string.Empty, $"{pi.ConfigFile.Name}.old"), true);
         }
     }
 

--- a/src/Athavar.FFXIV.Plugin.CraftSimulator/Models/Actions/Buff/FinalAppraisal.cs
+++ b/src/Athavar.FFXIV.Plugin.CraftSimulator/Models/Actions/Buff/FinalAppraisal.cs
@@ -8,33 +8,36 @@ internal sealed class FinalAppraisal : BuffAction
 {
     private static readonly uint[] IdsValue = { 19012, 19013, 19014, 19015, 19016, 19017, 19018, 19019 };
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     public override ActionType ActionType => ActionType.Buff;
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     public override int Level => 42;
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     public override CraftingClass Class => CraftingClass.ANY;
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     protected override uint[] Ids => IdsValue;
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     public override int GetBaseCPCost(Simulation simulation) => 1;
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     public override int GetDuration(Simulation simulation) => 5;
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     public override Buffs GetBuff() => Buffs.FINAL_APPRAISAL;
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     public override int GetInitialStacks() => 0;
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
+    public override bool IsSkipsBuffTicks() => true;
+
+    /// <inheritdoc/>
     protected override OnTick? GetOnTick() => null;
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     protected override bool CanBeClipped() => true;
 }


### PR DESCRIPTION
- fix final appraisal is skipping buff tick
- fix rename of old configuration from f5a5aa3192104ec6de90818356f21be788541a78