### PR TITLE
[AutoSpear] Add support for multiple fish in name matcher

### DIFF
--- a/src/Athavar.FFXIV.Plugin.AutoSpear/AutoSpear.Logic.cs
+++ b/src/Athavar.FFXIV.Plugin.AutoSpear/AutoSpear.Logic.cs
@@ -4,6 +4,7 @@
 // </copyright>
 namespace Athavar.FFXIV.Plugin.AutoSpear;
 
+using System.Linq.Expressions;
 using System.Text.RegularExpressions;
 using Athavar.FFXIV.Plugin.AutoSpear.Enum;
 using Athavar.FFXIV.Plugin.AutoSpear.SeFunctions;
@@ -66,11 +67,31 @@ internal sealed partial class AutoSpear
 
         this.fishData[index] = $"Line {index}: {(int)center}, x1={(int)posStart}, x2={(int)posEnd}, Speed={info.Speed}, Size={info.Size}, Name: {text}";
 
-        if (this.configuration.FishMatchText is null || !Regex.IsMatch(text, this.configuration.FishMatchText))
+        // skips the name matching if "FishMatchText" is empty
+        if (string.IsNullOrWhiteSpace(this.configuration.FishMatchText))
+        {
+            goto Catch;
+        }
+
+        var patterns = this.configuration.FishMatchText
+            .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        bool matches = false;
+        foreach (var pattern in patterns)
+        {
+            if (Regex.IsMatch(text, pattern))
+            {
+                matches = true;
+                break;
+            }
+        }
+
+        if (!matches)
         {
             return;
         }
 
+    Catch:
         var indexReduction = fishWide * 0.2f * (2 - index);
         posStart += indexReduction;
         posEnd -= indexReduction;


### PR DESCRIPTION
Added the ability to have multiple fish in the "Spear Fish Name Matcher" each fish's name separated by semicolons. 
<img width="586" height="310" alt="image" src="https://github.com/user-attachments/assets/1c674d6b-b12b-4925-afe9-d7d49205eb43" />
im not used to visual studio so i made a mess in the git log on my previous pull-request trying to an oversight but this should be good now
tested it it with multiple fish names (like in the screenshot) and without any and it behaves the same as the old version in the case of nothing